### PR TITLE
Return 1 nbproc if an exception is raised, as well

### DIFF
--- a/lib/haproxyctl/environment.rb
+++ b/lib/haproxyctl/environment.rb
@@ -39,7 +39,11 @@ module HAProxyCTL
     def nbproc 
       @nbproc ||= begin
         config.match /nbproc \s*(\d*)\s*/
-        Regexp.last_match[1].to_i || 1
+        begin
+          Regexp.last_match[1].to_i || 1
+        rescue
+          1
+        end
       end
     end
 


### PR DESCRIPTION
Found the cause of the exception:
https://github.com/easybiblabs/haproxyctl/blob/master/lib/haproxyctl/environment.rb#L42 doesn't catch the case, that Regexp explodes all together raising an exception. It should just fall-back to 1 in any case, always, even if an exception is raised.